### PR TITLE
Modify API clientId and scope condition

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -60,10 +60,10 @@
           }
       }
       
-      if(defaultUrl.includes("suiteapi")) {
-         clientId = "api://medius-suite-dev";
-         defaultScope = "api://medius-suite-dev/SwaggerUI";
-         appName = "Medius Suite API";
+      if (defaultUrl.includes("suiteapi") || defaultUrl.includes("privateapi")) {
+        clientId = "api://medius-suite-dev";
+        defaultScope = "api://medius-suite-dev/SwaggerUI";
+        appName = "Medius Suite API";
       }
       
       // Begin Swagger UI call region


### PR DESCRIPTION
The authentication does not work with links shared for private api:

https://api.medius.com/test/documentation/?url=https://api.medius.com/test/privateapi/master

You need to run the Suite API path first and then switch for the auth to work:
https://api.medius.com/test/documentation/?url=https://api.medius.com/test/suiteapi/master
